### PR TITLE
Proposal/pisp tx subscribers

### DIFF
--- a/proposals/adrianhopebailie-201908.md
+++ b/proposals/adrianhopebailie-201908.md
@@ -605,7 +605,7 @@ Where `SubscriptionRole` is a enum of the following values:
 | ------------------ | ------------------------------------------ | 
 | `PAYER`            | The sender of the funds                    | 
 | `PAYEE`            | The recipient of the funds                 | 
-| `INITIATOR`        | The participant initiating the transaction | 
+| `PISP`        | The participant initiating the transaction | 
 
 
 The `subscribers` list is included in the following request bodies:
@@ -645,7 +645,7 @@ has initiated a transaction:
     },
     {
       "id": "pispA",
-      "role": "INITIATOR"
+      "role": "PISP"
     },   
   ]
 ```
@@ -819,7 +819,7 @@ but mark it as deprecated, to be removed in `v3.0` of the API
 | ------------------ | ------------------------------------------ | 
 | `PAYER`            | The sender of the funds                    | 
 | `PAYEE`            | The recipient of the funds                 | 
-| `INITIATOR`        | The participant initiating the transaction | 
+| `PISP`        | The participant initiating the transaction | 
 
 
 A `subscribers` list is expressed as:
@@ -937,7 +937,7 @@ FSPIOP-Destination: dfspB
     },
     {
       "id": "pispA",
-      "role": "INITIATOR"
+      "role": "PISP"
     },   
   ]
 }


### PR DESCRIPTION
- Adds a new `Subscribers` object to the `POST /quotes` body and Transaction object
- Additional data models as required
- Didn't touch any existing proposals, but there may be a need to update them given the age of this proposal

@adrianhopebailie I'm not so experienced with writing docs like these, so any tips or areas for improvement would be greatly appreciated!